### PR TITLE
Generalize site to broader industrial inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Industrial Surplus Hub – Static Catalog Site
 
-This repository contains a fully‑static HTML/CSS/JS catalog for surplus gear grinding wheels.  The site has been built to be fast, mobile‑friendly and secure while exposing only buyer‑relevant information.
+This repository contains a fully‑static HTML/CSS/JS catalog for surplus industrial equipment. The site has been built to be fast, mobile‑friendly and secure while exposing only buyer‑relevant information. Current data focuses on gear grinding wheels but the layout supports other categories.
 
 ## Structure
 
 ```
 ├── index.html                  # Home page
-├── catalog.html                # Grid/list of all wheels
+├── catalog.html                # Inventory listing page
 ├── contact.html                # Contact form using Formspree
-├── *.html                      # Individual wheel detail pages (one per wheel)
+├── *.html                      # Individual item detail pages (one per item)
 ├── catalog.csv                 # Master catalog data (for future import/export)
 ├── assets/
 │   ├── css/style.css           # Single CSS file for layout and styling
@@ -18,11 +18,11 @@ This repository contains a fully‑static HTML/CSS/JS catalog for surplus gear g
 
 ## Development
 
-All pages are static and can be previewed locally by opening `index.html` in your browser.  If you wish to modify catalog entries or add new wheels in the future:
+All pages are static and can be previewed locally by opening `index.html` in your browser. If you wish to modify catalog entries or add new items in the future:
 
 1.  Update `catalog.csv` with a new row using the existing header structure.  Keep descriptions short and avoid any proprietary information.
-2.  Place two optimized images for the wheel into `assets/web_images/` and reference them in the `photo1` and `photo2` columns (omit `photo2` if you only have one photo).
-3.  Rebuild the HTML files by running the Python generator script used during initial creation (not included here).  For simple updates you can manually duplicate an existing detail page and adjust the fields.
+2.  Place two optimized images for the item into `assets/web_images/` and reference them in the `photo1` and `photo2` columns (omit `photo2` if you only have one photo).
+3.  Rebuild the HTML files by running the Python generator script used during initial creation (not included here). For simple updates you can manually duplicate an existing detail page and adjust the fields.
 
 ## Deployment on Cloudflare Pages
 

--- a/assets/js/catalog.js
+++ b/assets/js/catalog.js
@@ -7,22 +7,27 @@ async function loadCatalog() {
     const params = new URLSearchParams(window.location.search);
     const query = (params.get('q') || '').toLowerCase();
     const items = query
-      ? data.filter(item =>
-          item.brand.toLowerCase().includes(query) ||
-          item.grinding_type.toLowerCase().includes(query) ||
-          item.description.toLowerCase().includes(query))
+      ? data.filter(item => {
+          const type = (item.item_type || item.grinding_type || '').toLowerCase();
+          return (
+            item.brand.toLowerCase().includes(query) ||
+            type.includes(query) ||
+            item.description.toLowerCase().includes(query)
+          );
+        })
       : data;
 
     items.forEach(item => {
       const card = document.createElement('div');
       card.className = 'card';
+      const type = item.item_type || item.grinding_type || '';
       card.innerHTML = `
         <a href="${item.slug}.html">
-          <img src="${item.photo1}" alt="${item.brand} ${item.grinding_type}" loading="lazy">
+          <img src="${item.photo1}" alt="${item.brand} ${type}" loading="lazy">
         </a>
         <div class="card-body">
-          <h3>${item.brand} ${item.grinding_type}</h3>
-          <p>Size: ${item.size_od_in}″ OD × ${item.size_width_in}″ W × ${item.size_id_in}″ ID</p>
+          <h3>${item.brand} ${type}</h3>
+          <p>${item.size_od_in}″ OD × ${item.size_width_in}″ W × ${item.size_id_in}″ ID</p>
           <a class="btn-small" href="${item.slug}.html">View Details</a>
         </div>
       `;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -6,12 +6,13 @@ async function loadFeatured() {
     data.slice(0, 3).forEach(item => {
       const card = document.createElement('div');
       card.className = 'card';
+      const type = item.item_type || item.grinding_type || '';
       card.innerHTML = `
         <a href="${item.slug}.html">
-          <img src="${item.photo1}" alt="${item.brand} ${item.grinding_type}" loading="lazy">
+          <img src="${item.photo1}" alt="${item.brand} ${type}" loading="lazy">
         </a>
         <div class="card-body">
-          <h3>${item.brand} ${item.grinding_type}</h3>
+          <h3>${item.brand} ${type}</h3>
           <p>${item.size_od_in}″ OD × ${item.size_width_in}″ W × ${item.size_id_in}″ ID</p>
           <a class="btn-small" href="${item.slug}.html">View Details</a>
         </div>

--- a/catalog.html
+++ b/catalog.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Wheel Catalog | Industrial Surplus Hub</title>
+<title>Inventory | Industrial Surplus Hub</title>
 <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
@@ -11,16 +11,16 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href="index.html">Home</a>
-    <a href="catalog.html">Wheel Catalog</a>
+    <a href="catalog.html">Inventory</a>
     <a href="contact.html">Contact</a>
   </nav>
   <form class="search-form" action="catalog.html" method="GET">
-    <input type="search" name="q" placeholder="Search wheels" aria-label="Search wheels">
+    <input type="search" name="q" placeholder="Search inventory" aria-label="Search inventory">
     <button type="submit">Search</button>
   </form>
 </header>
 <main>
-  <h2>Wheel Catalog</h2>
+  <h2>Inventory</h2>
 
   <div id="catalog-grid" class="catalog-grid"></div>
 </main>

--- a/contact.html
+++ b/contact.html
@@ -11,17 +11,17 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href="index.html">Home</a>
-    <a href="catalog.html">Wheel Catalog</a>
+    <a href="catalog.html">Inventory</a>
     <a href="contact.html">Contact</a>
   </nav>
   <form class="search-form" action="catalog.html" method="GET">
-    <input type="search" name="q" placeholder="Search wheels" aria-label="Search wheels">
+    <input type="search" name="q" placeholder="Search inventory" aria-label="Search inventory">
     <button type="submit">Search</button>
   </form>
 </header>
 <main>
   <h2>Contact Us</h2>
-  <p>Need more information about a specific grinding wheel or want to request a quote? Send us a message and our team will get back to you promptly.</p>
+  <p>Need more information about a specific item from our surplus inventory or want to request a quote? Send us a message and our team will get back to you promptly.</p>
   <form action="https://formspree.io/f/your-form-id" method="POST" class="contact-form">
     <label for="name">Name</label>
     <input type="text" id="name" name="name" required>

--- a/flange-hub.html
+++ b/flange-hub.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -11,28 +11,28 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href="index.html">Home</a>
-    <a href="catalog.html">Wheel Catalog</a>
+    <a href="catalog.html">Inventory</a>
     <a href="contact.html">Contact</a>
   </nav>
   <form class="search-form" action="catalog.html" method="GET">
-    <input type="search" name="q" placeholder="Search wheels" aria-label="Search wheels">
+    <input type="search" name="q" placeholder="Search inventory" aria-label="Search inventory">
     <button type="submit">Search</button>
   </form>
 </header>
 <main>
-  <section class="hero">
-    <h2>Surplus Gear Grinding Wheels</h2>
-    <p>We offer a curated selection of surplus Kapp Niles CBN electroplated wheels and conventional vitrified grinding wheels. Every listing is carefully inspected and accompanied by essential specifications for your machining needs. Geometry reports are available to verified buyers upon request.</p>
-    <a class="btn" href="catalog.html">Browse Catalog</a>
-  </section>
-  <section class="featured">
-    <h2>Featured Wheels</h2>
+    <section class="hero">
+      <h2>Quality Surplus Equipment</h2>
+      <p>We offer a curated selection of industrial surplus—from gear grinding wheels to precision tooling. Every listing is carefully inspected and includes key specifications for your machining needs. Detailed documentation is available to verified buyers upon request.</p>
+      <a class="btn" href="catalog.html">Browse Inventory</a>
+    </section>
+    <section class="featured">
+      <h2>Featured Items</h2>
     <div id="featured-list" class="catalog-grid"></div>
   </section>
   <section class="features">
     <div class="feature">
       <h3>Trusted Quality</h3>
-      <p>All our grinding wheels are sourced from reputable brands such as Kapp Niles, Radiac, Norton and Winterthur. Our team inspects and groups each wheel to ensure you receive only buyer‑relevant information.</p>
+        <p>All our equipment is sourced from reputable brands. Our team inspects each item to ensure you receive only buyer‑relevant information.</p>
     </div>
     <div class="feature">
       <h3>Protecting Your IP</h3>

--- a/kapp-cbn-10in-hub.html
+++ b/kapp-cbn-10in-hub.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-10in-kn0024.html
+++ b/kapp-cbn-10in-kn0024.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-10in-kn0041.html
+++ b/kapp-cbn-10in-kn0041.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-10in-set.html
+++ b/kapp-cbn-10in-set.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-10in-set2.html
+++ b/kapp-cbn-10in-set2.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-10in-set3.html
+++ b/kapp-cbn-10in-set3.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-10in.html
+++ b/kapp-cbn-10in.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-11in.html
+++ b/kapp-cbn-11in.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-12in.html
+++ b/kapp-cbn-12in.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-9in-6bolt.html
+++ b/kapp-cbn-9in-6bolt.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-cbn-9in-gold.html
+++ b/kapp-cbn-9in-gold.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/kapp-single-flank-10in.html
+++ b/kapp-single-flank-10in.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/norton-brown.html
+++ b/norton-brown.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/precision-hole-gage.html
+++ b/precision-hole-gage.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/radiac-16x125.html
+++ b/radiac-16x125.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/radiac-16x175.html
+++ b/radiac-16x175.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>

--- a/winterthur-14x075.html
+++ b/winterthur-14x075.html
@@ -11,7 +11,7 @@
   <h1>Industrial Surplus Hub</h1>
   <nav>
     <a href='index.html'>Home</a>
-    <a href='catalog.html'>Wheel Catalog</a>
+    <a href='catalog.html'>Inventory</a>
     <a href='contact.html'>Contact</a>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- Rebrand navigation and copy to emphasize a general industrial surplus inventory
- Update JavaScript to handle generic item types when rendering featured and catalog listings
- Refresh README and contact copy to reflect broader scope

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906815d1c0832eaaca36db2d945e0a