### PR TITLE
refactor: avoid innerHTML

### DIFF
--- a/assets/js/catalog.js
+++ b/assets/js/catalog.js
@@ -21,15 +21,27 @@ async function loadCatalog() {
       const card = document.createElement('div');
       card.className = 'card';
 
-      card.innerHTML = `
-        <a href="${item.slug}.html">
-          <img src="${item.photo1}" alt="${item.brand} ${type}" loading="lazy">
-        </a>
-        <div class="card-body">
+      const link = document.createElement('a');
+      link.href = `${item.slug}.html`;
 
-          <a class="btn-small" href="${item.slug}.html">View Details</a>
-        </div>
-      `;
+      const img = document.createElement('img');
+      const type = item.item_type || item.grinding_type || '';
+      img.src = item.photo1;
+      img.alt = `${item.brand} ${type}`.trim();
+      img.loading = 'lazy';
+      link.appendChild(img);
+
+      const cardBody = document.createElement('div');
+      cardBody.className = 'card-body';
+
+      const btn = document.createElement('a');
+      btn.className = 'btn-small';
+      btn.href = `${item.slug}.html`;
+      btn.textContent = 'View Details';
+      cardBody.appendChild(btn);
+
+      card.appendChild(link);
+      card.appendChild(cardBody);
       grid.appendChild(card);
     });
   } catch (err) {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -7,15 +7,27 @@ async function loadFeatured() {
       const card = document.createElement('div');
       card.className = 'card';
 
-      card.innerHTML = `
-        <a href="${item.slug}.html">
-          <img src="${item.photo1}" alt="${item.brand} ${type}" loading="lazy">
-        </a>
-        <div class="card-body">
+      const link = document.createElement('a');
+      link.href = `${item.slug}.html`;
 
-          <a class="btn-small" href="${item.slug}.html">View Details</a>
-        </div>
-      `;
+      const img = document.createElement('img');
+      const type = item.item_type || item.grinding_type || '';
+      img.src = item.photo1;
+      img.alt = `${item.brand} ${type}`.trim();
+      img.loading = 'lazy';
+      link.appendChild(img);
+
+      const cardBody = document.createElement('div');
+      cardBody.className = 'card-body';
+
+      const btn = document.createElement('a');
+      btn.className = 'btn-small';
+      btn.href = `${item.slug}.html`;
+      btn.textContent = 'View Details';
+      cardBody.appendChild(btn);
+
+      card.appendChild(link);
+      card.appendChild(cardBody);
       list.appendChild(card);
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- build featured and catalog cards using DOM APIs instead of `innerHTML` to avoid unsafe injection
- compute item type for alt text and set attributes via `createElement` and `textContent`

## Testing
- `node --check assets/js/index.js`
- `node --check assets/js/catalog.js`

------
https://chatgpt.com/codex/tasks/task_e_68978921fed4832e95eeba0661080a49